### PR TITLE
inequality-based urban water security model

### DIFF
--- a/urban-water-security-v1-inequality-based.nlogo
+++ b/urban-water-security-v1-inequality-based.nlogo
@@ -1,0 +1,1124 @@
+breed [residents resident]
+
+residents-own [
+  income                    ; agents received a unique but fixed income per household
+  infrastructure            ; the performance of infrastructure is a function of public and private infrastructure
+  private-infrastructure    ; private infrastructure of the household
+  damage                    ; absolute level of infrastructure dependent on the market value of the property and the level of infrastructure to dampen the impact of events
+  past-events               ; intensity of events in past x time steps
+  private-invest            ; every time step the agent decides to invest or not in private infrastructure
+  order                     ; ordering residents on income
+  intensity                 ; intensity of events experienced at household level
+]
+
+patches-own [
+  price                     ; average income of residents in this neighborhood impacting property value and absolute level of damage
+  public-infrastructure     ; level of public infrastructure in the neighborhood
+  damagelevel               ; mean damage of residents in the neighborhood
+  nrresidents               ; the number of residents in the neighborhood
+  public-invest             ; amount of public investment in neighborhood infrastructure
+  past-damagelevels         ; sum of damage of residents in the neighborhood in the past x time steps
+  past-incomelevels         ; sum of income of residents in the neighborhood in the past x time steps
+  relativedamage            ; the relative damage of residents received during the last x time steps
+]
+
+globals [
+  gini-price                ; average gini coefficient of the prices of houses in all neighborhoods
+  gini-damage
+  average-damage            ; average damage as fraction of income of residents
+  cum-average-damage        ; cumulated damage after tick 400
+  cum-public-infrastructure ; cumulated public infrastructure after tick 400
+  cum-private-infrastructure ; cumulated private infrastructure after tick 400
+ ; alpha beta                ; parameter of the Cobb-Douglass production of infrastructure performance
+ ; decay-public decay-private ; decay rates of public and private infrastructure
+  budget                    ; budget to be allocated each tick
+  priority-invest           ; scenario that defined priority how to invest budget
+]
+
+to setup
+  clear-all
+  set-default-shape residents "circle"
+  let number-residents 36 * 49
+  create-residents number-residents [
+    set income exp (random-normal 0 SD) ; SD represents the standard deviation, the higher it is, the greater the inequality
+    set size 0.1
+    set damage 0
+    set infrastructure 1
+    set private-infrastructure 1
+    set past-events [0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1]
+  ]
+  let i 0
+  foreach sort-on [income] residents
+  [ the-turtle -> ask the-turtle [ set order i set i i + 1 ] ]
+
+  let order-i 0
+  ask patches [
+    set pcolor white
+    set i 0
+    let j 0
+    let patchnumber pxcor + pxcor * 6
+    let pxcor-patch pxcor
+    let pycor-patch pycor
+
+    let qj (patchnumber + 1) / (49 - 1) + (1 - 2 * (patchnumber + 1) / (49 - 1)) * 7
+    set qj qj * 36
+    set qj int qj
+    let order-j 0
+    while [order-j < 36] [
+      ask one-of residents with [order = order-i] [
+        set xcor pxcor-patch - 0.35 + 0.14 * i
+        set ycor pycor-patch - 0.35 + 0.14 * j
+        set i i + 1
+        if i mod 6 = 0 [set j j + 1 set i 0]
+        set order-i order-i + 1
+        set order-j order-j + 1
+      ]
+    ]
+    set public-infrastructure 1
+  ]
+  ; create some space to move
+
+  ask patches [
+    set price mean [income] of residents-here
+    set damagelevel mean [damage] of residents-here
+    set past-damagelevels [0 0 0 0 0 0 0 0 0 0]
+    set past-incomelevels [1 1 1 1 1 1 1 1 1 1]
+  ]
+ ; set alpha 0.4
+ ; set beta 0.4
+;  set decay-public 0.02
+;  set decay-private 0.03
+
+  if priority-public-investments = "low infrastructure" [set priority-invest 0]
+  if priority-public-investments = "recent high damage" [set priority-invest 1]
+  if priority-public-investments = "recent high relative damage" [set priority-invest 2]
+
+  reset-ticks
+  update-colors
+end
+
+to go
+  events
+  update-infrastructure
+  update-colors
+  tick
+end
+
+to update-colors
+  ask patches [
+    set price 0.001
+    set damagelevel 0
+    if count residents-here > 0 [
+      set price mean [income] of residents-here
+      set damagelevel mean [damage] of residents-here
+    ]
+  ]
+  if visualization = "income" [
+    ask patches [set pcolor scale-color green price 0 10]
+    ask residents [set color scale-color red income 0 10]
+  ]
+  if visualization = "damage" [
+    ask patches [set pcolor scale-color red damagelevel 0 0.1]
+    ask residents [set color scale-color red damage 0 1]
+  ]
+  if visualization = "infrastructure" [
+    ask patches [
+        ifelse count residents-here > 0
+        [
+          set pcolor scale-color blue mean [infrastructure] of residents-here 0 2
+       ][
+         set pcolor white
+       ]
+    ]
+  ]
+
+  set gini-price 0
+  set gini-damage 0
+  let i 0
+  let j 0
+  while [i < 7]
+  [
+    while [j < 7]
+    [
+      let i2 0
+      let j2 0
+      while [i2 < 7]
+      [
+        while [j2 < 7]
+        [
+          set gini-price gini-price + abs ([price] of patch i j - [price] of patch i2 j2)
+          set gini-damage gini-damage + abs (([damagelevel] of patch i j / [price] of patch i j) - ([damagelevel] of patch i2 j2 / [price] of patch i2 j2))
+          set j2 j2 + 1
+        ]
+       set j2 0
+        set i2 i2 + 1
+      ]
+      set j j + 1
+    ]
+    set j 0
+    set i i + 1
+  ]
+
+  set gini-price gini-price / (2 * mean [price] of patches * 49 * 49)
+  if mean [damagelevel] of patches > 0 [
+    set gini-damage gini-damage / (2 * mean [damagelevel] of patches * 49 * 49)]
+
+  set average-damage sum [damage] of residents / sum [income] of residents
+  if ticks >= 100 [
+    set cum-average-damage cum-average-damage + average-damage
+    set cum-public-infrastructure cum-public-infrastructure + mean [public-infrastructure] of patches
+    set cum-private-infrastructure cum-private-infrastructure + mean [private-infrastructure] of residents
+  ]
+
+  ask patches [
+    set i 0
+    set j 0
+    ask residents-here [
+
+      set xcor pxcor - 0.35 + 0.14 * i
+      set ycor pycor - 0.35 + 0.14 * j
+      set i i + 1
+      if i mod 6 = 0 [set j j + 1 set i 0]
+    ]
+  ]
+
+  ask patches [set nrresidents count residents-here]
+end
+
+
+to update-infrastructure
+  set budget budget-scen
+  ask patches [
+    set public-infrastructure public-infrastructure * (1 - decay-public)
+  ]
+  ask residents [
+    set private-infrastructure private-infrastructure * (1 - decay-private)
+  ]
+  ask residents [
+    set infrastructure (public-infrastructure ^ alpha) * (private-infrastructure ^ beta)
+  ]
+
+  private-infrastructure-provision
+  public-infrastructure-provision
+end
+
+to private-infrastructure-provision
+
+  ; calculate benefit of investing one unit in private infrastructure
+  ask residents [
+   let i 0
+   let e-lessdamage 0
+   let e-infrastructure (public-infrastructure ^ alpha) * ((private-infrastructure + 1) ^ beta)
+   while [i < 10]
+   [
+      if item i past-events > 0 [
+        set e-lessdamage e-lessdamage + price * (1 - (dmax / (1 + exp (gamma * (item i past-events - 1 - infrastructure))))) - price * (1 - (dmax / (1 + exp (gamma * (item i past-events - 1 - e-infrastructure)))))
+      ]
+     set i i + 1
+   ]
+    ifelse (e-lessdamage / 10) >= 0.1 [set private-invest 1][set private-invest 0]
+    set private-infrastructure private-infrastructure + private-invest
+    set infrastructure (public-infrastructure ^ alpha) * (private-infrastructure ^ beta)
+  ]
+end
+
+to public-infrastructure-provision
+  ask patches [ set public-invest 0]
+
+  ; prioritize neighborhoods with low infrastructure
+  if priority-invest = 0 [
+    foreach sort-on [public-infrastructure] patches [
+      the-patch -> ask the-patch [if budget > 0 [set public-invest 1 set budget budget - 1]]
+    ]
+  ]
+  ; prioritize neighborhoods with high damage in last 10 ticks
+  if priority-invest = 1 [
+    foreach sort-on [(- mean past-damagelevels)] patches [
+      the-patch -> ask the-patch [if budget > 0 [set public-invest 1 set budget budget - 1]]
+    ]
+  ]
+  ; prioritize neighbors with relative high damage related to income
+  if priority-invest = 2 [
+    foreach sort-on [(- relativedamage)] patches [
+      the-patch -> ask the-patch [if budget > 0 [set public-invest 1 set budget budget - 1]]
+    ]
+  ]
+  ask patches [
+    set public-infrastructure public-infrastructure + public-invest
+  ]
+  ask residents [
+   set infrastructure (public-infrastructure ^ alpha) * (private-infrastructure ^ beta)
+  ]
+end
+
+to events
+  let intensity-c random-exponential event-exp
+  ask residents [set damage 0 set intensity intensity-c]
+  ; individual events
+
+  ask residents [
+    set intensity intensity + random-exponential event-exp
+  ]
+  ask patches [
+    let intensity-n random-exponential event-exp
+    ask residents-here [
+      set intensity intensity + intensity-n]
+  ]
+;  ask residents [
+;     set intensity intensity-scen
+;  ]
+  ask residents [
+  ;  show price
+  ;  show (1 - dmax / (1 + exp (gamma * (intensity - infrastructure))))
+  ;  show intensity
+  ;  show infrastructure
+
+       set damage price * (1 - (dmax / (1 + exp (gamma * (intensity - 1 - infrastructure)))))
+   ;     show damage
+   ; show "z"
+       set past-events remove-item 0 past-events
+       set past-events lput intensity past-events
+  ]
+
+  ask patches [
+    set past-damagelevels remove-item 0 past-damagelevels
+    set past-damagelevels lput (sum [damage] of residents-here) past-damagelevels
+    set past-incomelevels remove-item 0 past-incomelevels
+    set past-incomelevels lput (sum [income] of residents-here) past-incomelevels
+    set relativedamage 0
+    if mean past-incomelevels > 0 [
+      set relativedamage mean past-damagelevels / mean past-incomelevels
+    ]
+  ]
+end
+@#$#@#$#@
+GRAPHICS-WINDOW
+210
+10
+568
+369
+-1
+-1
+50.0
+1
+10
+1
+1
+1
+0
+1
+1
+1
+0
+6
+0
+6
+0
+0
+1
+ticks
+30.0
+
+BUTTON
+2
+10
+65
+43
+NIL
+setup
+NIL
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+BUTTON
+68
+10
+131
+43
+NIL
+go
+T
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+SLIDER
+13
+243
+185
+276
+dmax
+dmax
+0
+1
+1.0
+0.01
+1
+NIL
+HORIZONTAL
+
+SLIDER
+16
+206
+188
+239
+gamma
+gamma
+0
+5
+5.0
+0.1
+1
+NIL
+HORIZONTAL
+
+BUTTON
+134
+10
+197
+43
+NIL
+go
+NIL
+1
+T
+OBSERVER
+NIL
+NIL
+NIL
+NIL
+1
+
+CHOOSER
+212
+374
+350
+419
+visualization
+visualization
+"income" "damage" "infrastructure"
+2
+
+PLOT
+580
+13
+882
+220
+Gini house prices
+NIL
+NIL
+0.0
+10.0
+0.0
+1.0
+true
+false
+"" ""
+PENS
+"default" 1.0 0 -16777216 true "" "plot gini-price"
+"pen-1" 1.0 0 -5298144 true "" "plot gini-damage"
+"intensity" 1.0 0 -14070903 true "" "plot mean [intensity] of residents / 10"
+
+PLOT
+581
+221
+881
+431
+relative damage
+NIL
+NIL
+0.0
+10.0
+0.0
+1.0
+true
+false
+"" ""
+PENS
+"default" 1.0 0 -16777216 true "" "plot average-damage"
+
+PLOT
+885
+14
+1197
+219
+investments
+NIL
+NIL
+0.0
+10.0
+0.0
+1.0
+true
+true
+"" ""
+PENS
+"private" 1.0 0 -14070903 true "" "plot mean [private-invest] of residents"
+"public" 1.0 0 -5298144 true "" "plot mean [public-invest] of patches"
+
+PLOT
+885
+221
+1198
+427
+infrastructure
+NIL
+NIL
+0.0
+10.0
+0.0
+2.0
+true
+true
+"" ""
+PENS
+"total" 1.0 0 -16777216 true "" "plot mean [infrastructure] of residents"
+"private" 1.0 0 -13840069 true "" "plot mean [private-infrastructure] of residents"
+"public" 1.0 0 -13345367 true "" "plot mean [public-infrastructure] of patches"
+
+SLIDER
+13
+279
+185
+312
+budget-scen
+budget-scen
+0
+50
+12.0
+1
+1
+NIL
+HORIZONTAL
+
+CHOOSER
+363
+375
+582
+420
+priority-public-investments
+priority-public-investments
+"low infrastructure" "recent high damage" "recent high relative damage"
+2
+
+SLIDER
+11
+55
+183
+88
+alpha
+alpha
+0
+1
+0.4
+0.01
+1
+NIL
+HORIZONTAL
+
+SLIDER
+13
+94
+185
+127
+beta
+beta
+0
+1
+0.4
+0.01
+1
+NIL
+HORIZONTAL
+
+SLIDER
+13
+132
+185
+165
+decay-public
+decay-public
+0
+1
+0.15
+0.01
+1
+NIL
+HORIZONTAL
+
+SLIDER
+18
+170
+190
+203
+decay-private
+decay-private
+0
+1
+0.15
+0.01
+1
+NIL
+HORIZONTAL
+
+SLIDER
+16
+319
+188
+352
+event-exp
+event-exp
+0
+3
+1.0
+0.1
+1
+NIL
+HORIZONTAL
+
+SLIDER
+180
+463
+352
+496
+intensity-scen
+intensity-scen
+0
+10
+1.5
+0.1
+1
+NIL
+HORIZONTAL
+
+CHOOSER
+25
+363
+163
+408
+SD
+SD
+0.3 0.4 0.5 0.6 0.7
+0
+
+@#$#@#$#@
+## WHAT IS IT?
+
+(a general understanding of what the model is trying to show or explain)
+
+## HOW IT WORKS
+
+(what rules the agents use to create the overall behavior of the model)
+
+## HOW TO USE IT
+
+(how to use the model, including a description of each of the items in the Interface tab)
+
+## THINGS TO NOTICE
+
+(suggested things for the user to notice while running the model)
+
+## THINGS TO TRY
+
+(suggested things for the user to try to do (move sliders, switches, etc.) with the model)
+
+## EXTENDING THE MODEL
+
+(suggested things to add or change in the Code tab to make the model more complicated, detailed, accurate, etc.)
+
+## NETLOGO FEATURES
+
+(interesting or unusual features of NetLogo that the model uses, particularly in the Code tab; or where workarounds were needed for missing features)
+
+## RELATED MODELS
+
+(models in the NetLogo Models Library and elsewhere which are of related interest)
+
+## CREDITS AND REFERENCES
+
+(a reference to the model's URL on the web if it has one, as well as any other necessary credits, citations, and links)
+@#$#@#$#@
+default
+true
+0
+Polygon -7500403 true true 150 5 40 250 150 205 260 250
+
+airplane
+true
+0
+Polygon -7500403 true true 150 0 135 15 120 60 120 105 15 165 15 195 120 180 135 240 105 270 120 285 150 270 180 285 210 270 165 240 180 180 285 195 285 165 180 105 180 60 165 15
+
+arrow
+true
+0
+Polygon -7500403 true true 150 0 0 150 105 150 105 293 195 293 195 150 300 150
+
+box
+false
+0
+Polygon -7500403 true true 150 285 285 225 285 75 150 135
+Polygon -7500403 true true 150 135 15 75 150 15 285 75
+Polygon -7500403 true true 15 75 15 225 150 285 150 135
+Line -16777216 false 150 285 150 135
+Line -16777216 false 150 135 15 75
+Line -16777216 false 150 135 285 75
+
+bug
+true
+0
+Circle -7500403 true true 96 182 108
+Circle -7500403 true true 110 127 80
+Circle -7500403 true true 110 75 80
+Line -7500403 true 150 100 80 30
+Line -7500403 true 150 100 220 30
+
+butterfly
+true
+0
+Polygon -7500403 true true 150 165 209 199 225 225 225 255 195 270 165 255 150 240
+Polygon -7500403 true true 150 165 89 198 75 225 75 255 105 270 135 255 150 240
+Polygon -7500403 true true 139 148 100 105 55 90 25 90 10 105 10 135 25 180 40 195 85 194 139 163
+Polygon -7500403 true true 162 150 200 105 245 90 275 90 290 105 290 135 275 180 260 195 215 195 162 165
+Polygon -16777216 true false 150 255 135 225 120 150 135 120 150 105 165 120 180 150 165 225
+Circle -16777216 true false 135 90 30
+Line -16777216 false 150 105 195 60
+Line -16777216 false 150 105 105 60
+
+car
+false
+0
+Polygon -7500403 true true 300 180 279 164 261 144 240 135 226 132 213 106 203 84 185 63 159 50 135 50 75 60 0 150 0 165 0 225 300 225 300 180
+Circle -16777216 true false 180 180 90
+Circle -16777216 true false 30 180 90
+Polygon -16777216 true false 162 80 132 78 134 135 209 135 194 105 189 96 180 89
+Circle -7500403 true true 47 195 58
+Circle -7500403 true true 195 195 58
+
+circle
+false
+0
+Circle -7500403 true true 0 0 300
+
+circle 2
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+
+cow
+false
+0
+Polygon -7500403 true true 200 193 197 249 179 249 177 196 166 187 140 189 93 191 78 179 72 211 49 209 48 181 37 149 25 120 25 89 45 72 103 84 179 75 198 76 252 64 272 81 293 103 285 121 255 121 242 118 224 167
+Polygon -7500403 true true 73 210 86 251 62 249 48 208
+Polygon -7500403 true true 25 114 16 195 9 204 23 213 25 200 39 123
+
+cylinder
+false
+0
+Circle -7500403 true true 0 0 300
+
+dot
+false
+0
+Circle -7500403 true true 90 90 120
+
+face happy
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 255 90 239 62 213 47 191 67 179 90 203 109 218 150 225 192 218 210 203 227 181 251 194 236 217 212 240
+
+face neutral
+false
+0
+Circle -7500403 true true 8 7 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Rectangle -16777216 true false 60 195 240 225
+
+face sad
+false
+0
+Circle -7500403 true true 8 8 285
+Circle -16777216 true false 60 75 60
+Circle -16777216 true false 180 75 60
+Polygon -16777216 true false 150 168 90 184 62 210 47 232 67 244 90 220 109 205 150 198 192 205 210 220 227 242 251 229 236 206 212 183
+
+fish
+false
+0
+Polygon -1 true false 44 131 21 87 15 86 0 120 15 150 0 180 13 214 20 212 45 166
+Polygon -1 true false 135 195 119 235 95 218 76 210 46 204 60 165
+Polygon -1 true false 75 45 83 77 71 103 86 114 166 78 135 60
+Polygon -7500403 true true 30 136 151 77 226 81 280 119 292 146 292 160 287 170 270 195 195 210 151 212 30 166
+Circle -16777216 true false 215 106 30
+
+flag
+false
+0
+Rectangle -7500403 true true 60 15 75 300
+Polygon -7500403 true true 90 150 270 90 90 30
+Line -7500403 true 75 135 90 135
+Line -7500403 true 75 45 90 45
+
+flower
+false
+0
+Polygon -10899396 true false 135 120 165 165 180 210 180 240 150 300 165 300 195 240 195 195 165 135
+Circle -7500403 true true 85 132 38
+Circle -7500403 true true 130 147 38
+Circle -7500403 true true 192 85 38
+Circle -7500403 true true 85 40 38
+Circle -7500403 true true 177 40 38
+Circle -7500403 true true 177 132 38
+Circle -7500403 true true 70 85 38
+Circle -7500403 true true 130 25 38
+Circle -7500403 true true 96 51 108
+Circle -16777216 true false 113 68 74
+Polygon -10899396 true false 189 233 219 188 249 173 279 188 234 218
+Polygon -10899396 true false 180 255 150 210 105 210 75 240 135 240
+
+house
+false
+0
+Rectangle -7500403 true true 45 120 255 285
+Rectangle -16777216 true false 120 210 180 285
+Polygon -7500403 true true 15 120 150 15 285 120
+Line -16777216 false 30 120 270 120
+
+leaf
+false
+0
+Polygon -7500403 true true 150 210 135 195 120 210 60 210 30 195 60 180 60 165 15 135 30 120 15 105 40 104 45 90 60 90 90 105 105 120 120 120 105 60 120 60 135 30 150 15 165 30 180 60 195 60 180 120 195 120 210 105 240 90 255 90 263 104 285 105 270 120 285 135 240 165 240 180 270 195 240 210 180 210 165 195
+Polygon -7500403 true true 135 195 135 240 120 255 105 255 105 285 135 285 165 240 165 195
+
+line
+true
+0
+Line -7500403 true 150 0 150 300
+
+line half
+true
+0
+Line -7500403 true 150 0 150 150
+
+pentagon
+false
+0
+Polygon -7500403 true true 150 15 15 120 60 285 240 285 285 120
+
+person
+false
+0
+Circle -7500403 true true 110 5 80
+Polygon -7500403 true true 105 90 120 195 90 285 105 300 135 300 150 225 165 300 195 300 210 285 180 195 195 90
+Rectangle -7500403 true true 127 79 172 94
+Polygon -7500403 true true 195 90 240 150 225 180 165 105
+Polygon -7500403 true true 105 90 60 150 75 180 135 105
+
+plant
+false
+0
+Rectangle -7500403 true true 135 90 165 300
+Polygon -7500403 true true 135 255 90 210 45 195 75 255 135 285
+Polygon -7500403 true true 165 255 210 210 255 195 225 255 165 285
+Polygon -7500403 true true 135 180 90 135 45 120 75 180 135 210
+Polygon -7500403 true true 165 180 165 210 225 180 255 120 210 135
+Polygon -7500403 true true 135 105 90 60 45 45 75 105 135 135
+Polygon -7500403 true true 165 105 165 135 225 105 255 45 210 60
+Polygon -7500403 true true 135 90 120 45 150 15 180 45 165 90
+
+sheep
+false
+15
+Circle -1 true true 203 65 88
+Circle -1 true true 70 65 162
+Circle -1 true true 150 105 120
+Polygon -7500403 true false 218 120 240 165 255 165 278 120
+Circle -7500403 true false 214 72 67
+Rectangle -1 true true 164 223 179 298
+Polygon -1 true true 45 285 30 285 30 240 15 195 45 210
+Circle -1 true true 3 83 150
+Rectangle -1 true true 65 221 80 296
+Polygon -1 true true 195 285 210 285 210 240 240 210 195 210
+Polygon -7500403 true false 276 85 285 105 302 99 294 83
+Polygon -7500403 true false 219 85 210 105 193 99 201 83
+
+square
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+
+square 2
+false
+0
+Rectangle -7500403 true true 30 30 270 270
+Rectangle -16777216 true false 60 60 240 240
+
+star
+false
+0
+Polygon -7500403 true true 151 1 185 108 298 108 207 175 242 282 151 216 59 282 94 175 3 108 116 108
+
+target
+false
+0
+Circle -7500403 true true 0 0 300
+Circle -16777216 true false 30 30 240
+Circle -7500403 true true 60 60 180
+Circle -16777216 true false 90 90 120
+Circle -7500403 true true 120 120 60
+
+tree
+false
+0
+Circle -7500403 true true 118 3 94
+Rectangle -6459832 true false 120 195 180 300
+Circle -7500403 true true 65 21 108
+Circle -7500403 true true 116 41 127
+Circle -7500403 true true 45 90 120
+Circle -7500403 true true 104 74 152
+
+triangle
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+
+triangle 2
+false
+0
+Polygon -7500403 true true 150 30 15 255 285 255
+Polygon -16777216 true false 151 99 225 223 75 224
+
+truck
+false
+0
+Rectangle -7500403 true true 4 45 195 187
+Polygon -7500403 true true 296 193 296 150 259 134 244 104 208 104 207 194
+Rectangle -1 true false 195 60 195 105
+Polygon -16777216 true false 238 112 252 141 219 141 218 112
+Circle -16777216 true false 234 174 42
+Rectangle -7500403 true true 181 185 214 194
+Circle -16777216 true false 144 174 42
+Circle -16777216 true false 24 174 42
+Circle -7500403 false true 24 174 42
+Circle -7500403 false true 144 174 42
+Circle -7500403 false true 234 174 42
+
+turtle
+true
+0
+Polygon -10899396 true false 215 204 240 233 246 254 228 266 215 252 193 210
+Polygon -10899396 true false 195 90 225 75 245 75 260 89 269 108 261 124 240 105 225 105 210 105
+Polygon -10899396 true false 105 90 75 75 55 75 40 89 31 108 39 124 60 105 75 105 90 105
+Polygon -10899396 true false 132 85 134 64 107 51 108 17 150 2 192 18 192 52 169 65 172 87
+Polygon -10899396 true false 85 204 60 233 54 254 72 266 85 252 107 210
+Polygon -7500403 true true 119 75 179 75 209 101 224 135 220 225 175 261 128 261 81 224 74 135 88 99
+
+wheel
+false
+0
+Circle -7500403 true true 3 3 294
+Circle -16777216 true false 30 30 240
+Line -7500403 true 150 285 150 15
+Line -7500403 true 15 150 285 150
+Circle -7500403 true true 120 120 60
+Line -7500403 true 216 40 79 269
+Line -7500403 true 40 84 269 221
+Line -7500403 true 40 216 269 79
+Line -7500403 true 84 40 221 269
+
+wolf
+false
+0
+Polygon -16777216 true false 253 133 245 131 245 133
+Polygon -7500403 true true 2 194 13 197 30 191 38 193 38 205 20 226 20 257 27 265 38 266 40 260 31 253 31 230 60 206 68 198 75 209 66 228 65 243 82 261 84 268 100 267 103 261 77 239 79 231 100 207 98 196 119 201 143 202 160 195 166 210 172 213 173 238 167 251 160 248 154 265 169 264 178 247 186 240 198 260 200 271 217 271 219 262 207 258 195 230 192 198 210 184 227 164 242 144 259 145 284 151 277 141 293 140 299 134 297 127 273 119 270 105
+Polygon -7500403 true true -1 195 14 180 36 166 40 153 53 140 82 131 134 133 159 126 188 115 227 108 236 102 238 98 268 86 269 92 281 87 269 103 269 113
+
+x
+false
+0
+Polygon -7500403 true true 270 75 225 30 30 225 75 270
+Polygon -7500403 true true 30 75 75 30 270 225 225 270
+@#$#@#$#@
+NetLogo 6.2.2
+@#$#@#$#@
+@#$#@#$#@
+@#$#@#$#@
+<experiments>
+  <experiment name="experiment" repetitions="1000" sequentialRunOrder="false" runMetricsEveryStep="false">
+    <setup>setup</setup>
+    <go>go</go>
+    <timeLimit steps="500"/>
+    <metric>gini-price</metric>
+    <metric>cum-average-damage / 100</metric>
+    <metric>cum-private-infrastructure / 100</metric>
+    <metric>cum-public-infrastructure / 100</metric>
+    <metric>priority-invest</metric>
+    <enumeratedValueSet variable="fraction-open">
+      <value value="0.1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="damage-threshold">
+      <value value="0.05"/>
+      <value value="0.15"/>
+      <value value="0.25"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="dmax-city">
+      <value value="0"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="dmax-neigh">
+      <value value="0.3"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="alpha">
+      <value value="1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="freq-ind">
+      <value value="0"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="visualization">
+      <value value="&quot;income&quot;"/>
+    </enumeratedValueSet>
+    <steppedValueSet variable="freq-neigh" first="0" step="0.2" last="1"/>
+    <enumeratedValueSet variable="dmax-ind">
+      <value value="0"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="freq-city">
+      <value value="0"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="budget-scen">
+      <value value="1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="gamma">
+      <value value="1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="priority-public-investments">
+      <value value="&quot;recent high damage&quot;"/>
+      <value value="&quot;recent high relative damage&quot;"/>
+    </enumeratedValueSet>
+  </experiment>
+  <experiment name="experiment" repetitions="1" sequentialRunOrder="false" runMetricsEveryStep="false">
+    <setup>setup</setup>
+    <go>go</go>
+    <timeLimit steps="500"/>
+    <metric>gini-price</metric>
+    <metric>cum-average-damage / 100</metric>
+    <metric>cum-private-infrastructure / 100</metric>
+    <metric>cum-public-infrastructure / 100</metric>
+    <metric>priority-invest</metric>
+    <enumeratedValueSet variable="fraction-open">
+      <value value="0.1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="damage-threshold">
+      <value value="0.05"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="dmax-city">
+      <value value="0.4"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="dmax-neigh">
+      <value value="0.3"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="alpha">
+      <value value="1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="freq-ind">
+      <value value="0.2"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="visualization">
+      <value value="&quot;income&quot;"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="freq-neigh">
+      <value value="0.1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="dmax-ind">
+      <value value="0.2"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="freq-city">
+      <value value="0.1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="budget-scen">
+      <value value="10"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="gamma">
+      <value value="1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="priority-public-investments">
+      <value value="&quot;3&quot;"/>
+    </enumeratedValueSet>
+  </experiment>
+  <experiment name="experimentnew" repetitions="100" sequentialRunOrder="false" runMetricsEveryStep="false">
+    <setup>setup</setup>
+    <go>go</go>
+    <timeLimit steps="200"/>
+    <metric>gini-price</metric>
+    <metric>gini-damage</metric>
+    <metric>cum-average-damage / 100</metric>
+    <metric>cum-private-infrastructure / 100</metric>
+    <metric>cum-public-infrastructure / 100</metric>
+    <enumeratedValueSet variable="decay-private">
+      <value value="0.15"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="dmax">
+      <value value="1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="gamma">
+      <value value="5"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="budget-scen">
+      <value value="4"/>
+      <value value="8"/>
+      <value value="12"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="event-exp">
+      <value value="0.2"/>
+      <value value="0.4"/>
+      <value value="0.6"/>
+      <value value="0.8"/>
+      <value value="1"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="alpha">
+      <value value="0.4"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="beta">
+      <value value="0.4"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="priority-public-investments">
+      <value value="&quot;recent high damage&quot;"/>
+      <value value="&quot;low infrastructure&quot;"/>
+      <value value="&quot;recent high relative damage&quot;"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="visualization">
+      <value value="&quot;infrastructure&quot;"/>
+    </enumeratedValueSet>
+    <enumeratedValueSet variable="decay-public">
+      <value value="0.15"/>
+    </enumeratedValueSet>
+  </experiment>
+</experiments>
+@#$#@#$#@
+@#$#@#$#@
+default
+0.0
+-0.2 0 0.0 1.0
+0.0 1 1.0 0.0
+0.2 0 0.0 1.0
+link direction
+true
+0
+Line -7500403 true 150 150 90 180
+Line -7500403 true 150 150 210 180
+@#$#@#$#@
+0
+@#$#@#$#@


### PR DESCRIPTION
The option of changing the standard deviation in the income distribution of the city's people was added so that by having different scenarios of the level of economic equality in the city, its relationship and effects can be investigated with respect to urban water security. This was done by adding a chooser to determine the standard deviation which includes 0.3, 0.4, 0.5, 0.6, and 0.7.